### PR TITLE
feat: add basic dashboard and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# GestorPensional
-herramienta pensional
+# Gestor Pensional
+
+Conjunto de herramientas web sencillas para apoyar la gestión pensional.
+
+## Uso
+
+1. Instala dependencias (ninguna por ahora).
+2. Ejecuta un servidor estático, por ejemplo:
+   ```bash
+   python3 -m http.server --directory public
+   ```
+3. Abre en el navegador `http://localhost:8000/index.html`.
+
+## Estructura
+
+- `data/municipios.json`: datos de municipios y requerimientos.
+- `public/`: archivos HTML, CSS y JS.
+  - `index.html`: panel principal de municipios.
+  - `municipio.html`: detalle de cada municipio.
+  - `plazos.html`: seguimiento de plazos.
+  - `plantillas.html`: generador simple de oficios.
+
+## Colores
+La paleta principal usa naranja (`#ff7f11`) y verde (`#2e7d32`).
+
+## Contribuciones
+Se aceptan mejoras mediante *pull requests*.

--- a/data/municipios.json
+++ b/data/municipios.json
@@ -1,0 +1,50 @@
+[
+  {
+    "nombre": "Bochalema",
+    "email_oficial": "bochalema@municipio.gov.co",
+    "estado_requerimientos": [
+      {"id": 1, "tipo": "Reclamación administrativa", "estado": "pendiente", "fecha_limite": "2024-06-10"},
+      {"id": 2, "tipo": "PASIVOCOL", "estado": "en proceso", "fecha_limite": "2024-07-01"}
+    ]
+  },
+  {
+    "nombre": "Cachira",
+    "email_oficial": "cachira@municipio.gov.co",
+    "estado_requerimientos": [
+      {"id": 1, "tipo": "Cuota parte", "estado": "pendiente", "fecha_limite": "2024-06-15"},
+      {"id": 2, "tipo": "CETIL", "estado": "finalizado", "fecha_limite": "2024-05-20"}
+    ]
+  },
+  {
+    "nombre": "Convencion",
+    "email_oficial": "convencion@municipio.gov.co",
+    "estado_requerimientos": [
+      {"id": 1, "tipo": "Saneamiento de aportes", "estado": "en proceso", "fecha_limite": "2024-06-25"},
+      {"id": 2, "tipo": "Generación de bonos", "estado": "pendiente", "fecha_limite": "2024-07-05"}
+    ]
+  },
+  {
+    "nombre": "La Esperanza",
+    "email_oficial": "laesperanza@municipio.gov.co",
+    "estado_requerimientos": [
+      {"id": 1, "tipo": "Fe de vida", "estado": "pendiente", "fecha_limite": "2024-06-08"},
+      {"id": 2, "tipo": "Reclamación administrativa", "estado": "en proceso", "fecha_limite": "2024-06-30"}
+    ]
+  },
+  {
+    "nombre": "Mutiscua",
+    "email_oficial": "mutiscua@municipio.gov.co",
+    "estado_requerimientos": [
+      {"id": 1, "tipo": "PASIVOCOL", "estado": "pendiente", "fecha_limite": "2024-06-18"},
+      {"id": 2, "tipo": "Cuota parte", "estado": "en proceso", "fecha_limite": "2024-07-02"}
+    ]
+  },
+  {
+    "nombre": "Puerto Santander",
+    "email_oficial": "puertosantander@municipio.gov.co",
+    "estado_requerimientos": [
+      {"id": 1, "tipo": "CETIL", "estado": "pendiente", "fecha_limite": "2024-06-12"},
+      {"id": 2, "tipo": "Reclamación administrativa", "estado": "en proceso", "fecha_limite": "2024-06-28"}
+    ]
+  }
+]

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,0 +1,75 @@
+:root {
+  --primary-orange: #ff7f11;
+  --primary-green: #2e7d32;
+  --light-bg: #f5f5f5;
+  --text-dark: #333;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: var(--light-bg);
+  color: var(--text-dark);
+}
+
+header {
+  background: var(--primary-green);
+  color: white;
+  padding: 1rem;
+  text-align: center;
+}
+
+.container {
+  padding: 1rem;
+}
+
+.card {
+  background: white;
+  border-radius: 8px;
+  padding: 1rem;
+  margin: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: transform 0.2s;
+}
+
+.card:hover {
+  transform: scale(1.02);
+}
+
+.button {
+  background: var(--primary-orange);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.button:hover {
+  background: #e06a00;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th, .table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.table th {
+  background: var(--primary-orange);
+  color: white;
+}
+
+.status-pendiente { color: #e65100; }
+.status-en\ proceso { color: var(--primary-green); }
+.status-finalizado { color: gray; }

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Dashboard de Municipios</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>Municipios Asignados</h1>
+  </header>
+  <div class="container" id="municipios">
+    <!-- Cards generadas por JS -->
+  </div>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('../data/municipios.json')
+    .then(res => res.json())
+    .then(municipios => {
+      const container = document.getElementById('municipios');
+      municipios.forEach(m => {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `
+          <h3>${m.nombre}</h3>
+          <p><strong>Correo:</strong> ${m.email_oficial}</p>
+          <button class="button" data-nombre="${m.nombre}">Ver detalles</button>
+        `;
+        container.appendChild(card);
+      });
+
+      container.addEventListener('click', e => {
+        if (e.target.matches('button')) {
+          const nombre = e.target.getAttribute('data-nombre');
+          window.location.href = `municipio.html?nombre=${encodeURIComponent(nombre)}`;
+        }
+      });
+    })
+    .catch(err => {
+      console.error('Error cargando municipios', err);
+    });
+});

--- a/public/js/plantillas.js
+++ b/public/js/plantillas.js
@@ -1,0 +1,18 @@
+function generarOficio() {
+  const nombre = document.getElementById('nombre').value;
+  const tipo = document.getElementById('tipo').value;
+  const radicado = document.getElementById('radicado').value;
+  const fundamento = document.getElementById('fundamento').value;
+  const contenido = `
+  <h2>Oficio - ${tipo}</h2>
+  <p>Señor(a) ${nombre},</p>
+  <p>Radicado: ${radicado}</p>
+  <p>${fundamento}</p>
+  <p>Cordialmente,</p>
+  <p><em>Asesor Pensional</em></p>`;
+  document.getElementById('resultado').innerHTML = contenido;
+}
+
+function descargarPDF() {
+  window.print();
+}

--- a/public/js/plazos.js
+++ b/public/js/plazos.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('../data/municipios.json')
+    .then(res => res.json())
+    .then(municipios => {
+      const allReq = [];
+      municipios.forEach(m => {
+        m.estado_requerimientos.forEach(r => {
+          allReq.push({
+            municipio: m.nombre,
+            ...r
+          });
+        });
+      });
+      allReq.sort((a,b) => new Date(a.fecha_limite) - new Date(b.fecha_limite));
+      const tbody = document.querySelector('#tabla-plazos tbody');
+      allReq.forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${r.municipio}</td><td>${r.tipo}</td><td class="status-${r.estado.replace(' ', '\\ ')}">${r.estado}</td><td>${r.fecha_limite}</td>`;
+        tbody.appendChild(tr);
+      });
+    });
+});

--- a/public/municipio.html
+++ b/public/municipio.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Detalle de Municipio</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1 id="titulo"></h1>
+  </header>
+  <div class="container">
+    <p><strong>Correo:</strong> <span id="correo"></span></p>
+    <h2>Requerimientos</h2>
+    <table class="table" id="tabla-requerimientos">
+      <thead>
+        <tr><th>ID</th><th>Tipo</th><th>Estado</th><th>Fecha límite</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <a href="index.html" class="button">Volver</a>
+  </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const params = new URLSearchParams(window.location.search);
+      const nombre = params.get('nombre');
+      fetch('../data/municipios.json')
+        .then(res => res.json())
+        .then(municipios => {
+          const mun = municipios.find(m => m.nombre === nombre);
+          if (mun) {
+            document.getElementById('titulo').textContent = mun.nombre;
+            document.getElementById('correo').textContent = mun.email_oficial;
+            const tbody = document.querySelector('#tabla-requerimientos tbody');
+            mun.estado_requerimientos.forEach(r => {
+              const tr = document.createElement('tr');
+              tr.innerHTML = `<td>${r.id}</td><td>${r.tipo}</td><td class="status-${r.estado.replace(' ', '\\ ')}">${r.estado}</td><td>${r.fecha_limite}</td>`;
+              tbody.appendChild(tr);
+            });
+          }
+        });
+    });
+  </script>
+</body>
+</html>

--- a/public/plantillas.html
+++ b/public/plantillas.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Generador de Plantillas</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>Generar Oficio</h1>
+  </header>
+  <div class="container">
+    <label>Nombre del peticionario:<br><input type="text" id="nombre"></label><br><br>
+    <label>Tipo de solicitud:<br><input type="text" id="tipo"></label><br><br>
+    <label>Número de radicado:<br><input type="text" id="radicado"></label><br><br>
+    <label>Fundamento legal:<br><textarea id="fundamento"></textarea></label><br><br>
+    <button class="button" onclick="generarOficio()">Generar</button>
+    <button class="button" onclick="descargarPDF()">Descargar PDF</button>
+    <div id="resultado" style="margin-top:1rem; background:white; padding:1rem;"></div>
+    <a href="index.html" class="button" style="margin-top:1rem; display:inline-block;">Volver</a>
+  </div>
+  <script src="js/plantillas.js"></script>
+</body>
+</html>

--- a/public/plazos.html
+++ b/public/plazos.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Seguimiento de Plazos</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>Plazos de Requerimientos</h1>
+  </header>
+  <div class="container">
+    <table class="table" id="tabla-plazos">
+      <thead>
+        <tr><th>Municipio</th><th>Tipo</th><th>Estado</th><th>Fecha límite</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <a href="index.html" class="button">Volver</a>
+  </div>
+  <script src="js/plazos.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add municipal dashboard and detail views
- provide simple template generator and deadline tracker
- include sample data and orange/green styling

## Testing
- `python3 -m http.server --directory public 8000`

------
https://chatgpt.com/codex/tasks/task_e_68a748b1f13c83238e15376e58ddef0d